### PR TITLE
Fixed uEnv.txt generation and thinned the encrypted install package list

### DIFF
--- a/encrypted-sata-install.sh
+++ b/encrypted-sata-install.sh
@@ -15,24 +15,9 @@ time sudo /bin/bash -x ./novena-image.sh \
 	-k kosagi.key \
 	-a u-boot-novena_2014.10-novena-rc12_armhf.deb \
 	-a irqbalance-imx_0.56-1ubuntu4-rmk1_armhf.deb \
-	-a libdrm-armada2_2.0.2-1_armhf.deb \
-	-a libdrm-armada2-dbg_2.0.2-1_armhf.deb \
-	-a libdrm-armada-dev_2.0.2-1_armhf.deb \
-	-a libetnaviv_0.0.0-r11_armhf.deb \
-	-a novena-usb-hub_1.0-1_armhf.deb \
-	-a libetnaviv-dbg_0.0.0-r11_armhf.deb \
-	-a libetnaviv-dev_0.0.0-r11_armhf.deb \
-	-a linux-headers-novena_1.14-r1_armhf.deb \
-	-a linux-image-novena_1.14-r1_armhf.deb \
-	-a novena-disable-ssp_1.1-1_armhf.deb \
 	-a novena-eeprom_2.1-1_armhf.deb \
-	-a novena-eeprom-gui_1.2-r1_armhf.deb \
 	-a kosagi-repo_1.0-r1_all.deb \
 	-a novena-firstrun_1.4-r1_all.deb \
-	-a xorg-novena_1.2-r1_all.deb \
-	-a xserver-xorg-video-armada_0.0.1-r1_armhf.deb \
-	-a xserver-xorg-video-armada-dbg_0.0.1-r1_armhf.deb \
-	-a xserver-xorg-video-armada-etnaviv_0.0.1-r1_armhf.deb \
 	-l "sudo openssh-server ntp ntpdate dosfstools novena-eeprom \
             xserver-xorg-video-modesetting arandr user-setup vim emacs \
 	    keychain locales evtest libbluetooth3 \

--- a/novena-image.sh
+++ b/novena-image.sh
@@ -386,7 +386,7 @@ create_initramfs() {
 	if [ -e "${root}/boot/uEnv.txt" ]; then
 		info "${root}/boot/uEnv.txt exists, not modifying"
 	else
-		uInitrd_size=$(wc -c "${root}/boot/uInitrd")
+		uInitrd_size=$(wc -c "${root}/boot/uInitrd" | cut -f 1 -d ' ')
 		initrd_addr_r=$(printf "0x%x" $(((0x11ff0000 - uInitrd_size) & 0xffff0000)))
 		echo -en 'earlyhook=if test "$rootdev" = "PARTUUID=4e6f7653-03"; then setenv rootdev /dev/mapper/crypt-root ; fi\0finalhook=if test "$rootdev" = "/dev/mapper/crypt-root"; then setenv initrd_addr_r '${initrd_addr_r}' ; fatload ${bootsrc} ${bootdev} ${initrd_addr_r} uInitrd ; fi' > "${root}/boot/uEnv.txt"
 	fi


### PR DESCRIPTION
With this status of the repo, I got the encryption to work from a new novena image, according to the post here: http://www.kosagi.com/forums/viewtopic.php?pid=1253#p1253